### PR TITLE
feat: Add product and single product pages for all templates

### DIFF
--- a/app/Http/Controllers/ProductController1.php
+++ b/app/Http/Controllers/ProductController1.php
@@ -51,4 +51,16 @@ class ProductController1 extends Controller
             ->with('is_default', false);
     }
 
+    public function showSingleProduct($headerFooterId, $productId)
+    {
+        $headerFooter = \App\Models\HeaderFooter::find($headerFooterId);
+        $product = \App\Models\Product::find($productId);
+
+        if (!$headerFooter || !$product) {
+            abort(404, 'Product not found');
+        }
+
+        return view('template1.single-product1', compact('headerFooter', 'product'))
+            ->with('is_default', false);
+    }
 }

--- a/app/Http/Controllers/ProductController2.php
+++ b/app/Http/Controllers/ProductController2.php
@@ -51,4 +51,16 @@ class ProductController2 extends Controller
             ->with('is_default', false);
     }
 
+    public function showSingleProduct($headerFooterId, $productId)
+    {
+        $headerFooter = \App\Models\HeaderFooter::find($headerFooterId);
+        $product = \App\Models\Product::find($productId);
+
+        if (!$headerFooter || !$product) {
+            abort(404, 'Product not found');
+        }
+
+        return view('template2.single-product2', compact('headerFooter', 'product'))
+            ->with('is_default', false);
+    }
 }

--- a/app/Http/Controllers/ProductController3.php
+++ b/app/Http/Controllers/ProductController3.php
@@ -25,6 +25,7 @@ class ProductController3 extends Controller
 
         $products = Product::where('header_footer_id', $headerFooter->id) ->get();
 
+
         return view('template3.product3', compact('headerFooter','products'))
             ->with('is_default', false);
     }
@@ -47,8 +48,21 @@ class ProductController3 extends Controller
 
         $products = Product::where('header_footer_id', $headerFooter->id)->get();
 
+
         return view('template3.product3', compact('headerFooter', 'products'))
             ->with('is_default', false);
     }
 
+    public function showSingleProduct($headerFooterId, $productId)
+    {
+        $headerFooter = HeaderFooter::find($headerFooterId);
+        $product = Product::find($productId);
+
+        if (!$headerFooter || !$product) {
+            abort(404, 'Product not found');
+        }
+
+        return view('template3.single-product3', compact('headerFooter', 'product'))
+            ->with('is_default', false);
+    }
 }

--- a/app/Http/Controllers/ProductController4.php
+++ b/app/Http/Controllers/ProductController4.php
@@ -51,4 +51,16 @@ class ProductController4 extends Controller
             ->with('is_default', false);
     }
 
+    public function showSingleProduct($headerFooterId, $productId)
+    {
+        $headerFooter = \App\Models\HeaderFooter::find($headerFooterId);
+        $product = \App\Models\Product::find($productId);
+
+        if (!$headerFooter || !$product) {
+            abort(404, 'Product not found');
+        }
+
+        return view('template4.single-product4', compact('headerFooter', 'product'))
+            ->with('is_default', false);
+    }
 }

--- a/resources/views/template1/head1.blade.php
+++ b/resources/views/template1/head1.blade.php
@@ -61,12 +61,14 @@
         
         @if($headerFooterId)
           <a href="/index1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+          <a href="/product1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
           <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
           <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
           <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
           <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
         @else
           <a href="/index1" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+          <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
           <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
           <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
           <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>

--- a/resources/views/template1/product1.blade.php
+++ b/resources/views/template1/product1.blade.php
@@ -85,12 +85,14 @@
                             <span class="absolute top-4 right-4 bg-red-600 text-white text-xs font-semibold px-2 py-1 rounded">LIMITED</span>
                         @endif
                     </div>
+                    <a href="{{ route('template1.single-product', ['headerFooterId' => $headerFooter->id, 'productId' => $product->id]) }}">
                     <h4 class="font-semibold text-lg mb-1">{{ $product->name }}</h4>
                     <p class="text-gray-600 text-sm mb-3">{{ $product->description }}</p>
                     <p class="text-green-700 font-bold text-xl mb-4">${{ number_format($product->price, 2) }}</p>
                     <button class="w-full bg-gray-900 hover:bg-gray-800 text-white py-2 rounded-lg font-medium transition flex items-center justify-center">
-                        <i class="fas fa-shopping-cart mr-2"></i> Add to Cart
+                        <i class="fas fa-shopping-cart mr-2"></i> View Product
                     </button>
+                    </a>
                 </div>
             @endforeach
         </div>

--- a/resources/views/template1/single-product1.blade.php
+++ b/resources/views/template1/single-product1.blade.php
@@ -1,0 +1,38 @@
+@include('template1.head1', ['is_default' => $is_default, 'headerFooter' => $headerFooter])
+
+<section class="py-20 px-6 bg-white">
+  <div class="max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+      <div>
+        <div class="relative h-[500px] mb-6 overflow-hidden rounded-lg">
+          <img src="{{ $product->image_url }}" alt="{{ $product->name }}" class="absolute inset-0 w-full h-full object-cover">
+        </div>
+      </div>
+      <div>
+        <h2 class="text-4xl font-medium mb-4">{{ $product->name }}</h2>
+        <p class="text-gray-600 mb-6">{{ $product->description }}</p>
+        <p class="text-gray-900 font-medium text-3xl mb-6">${{ number_format($product->price, 2) }}</p>
+        <div class="flex items-center mb-6">
+          <div class="flex text-yellow-500">
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star-half-alt"></i>
+          </div>
+          <p class="text-gray-600 ml-2">4.5 (1,234 reviews)</p>
+        </div>
+        <div class="flex space-x-4">
+          <button class="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 font-medium transition duration-300">
+            Add to Cart
+          </button>
+          <button class="border border-gray-300 hover:border-blue-600 text-gray-900 px-8 py-3 font-medium transition duration-300">
+            Add to Wishlist
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+@include('template1.footer1')

--- a/resources/views/template2/head2.blade.php
+++ b/resources/views/template2/head2.blade.php
@@ -83,12 +83,14 @@
           
           @if($headerFooterId)
             <a href="/index2/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+            <a href="/product2/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
             <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
             <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
           @else
             <a href="/index2" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+            <a href="/product2" class="text-gray-700 hover:text-pink-600 transition">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
             <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>

--- a/resources/views/template2/product2.blade.php
+++ b/resources/views/template2/product2.blade.php
@@ -39,12 +39,14 @@
                 <span class="absolute top-4 right-4 bg-red-600 text-white text-xs font-medium px-2 py-1 rounded">LIMITED</span>
               @endif
             </div>
+            <a href="{{ route('template2.single-product', ['headerFooterId' => $headerFooter->id, 'productId' => $product->id]) }}">
             <h4 class="font-medium text-lg mb-1">{{ $product->name }}</h4>
             <p class="text-gray-400 text-sm mb-3">{{ $product->description }}</p>
             <p class="text-yellow-600 font-medium text-xl mb-4">${{ number_format($product->price, 2) }}</p>
             <button class="w-full bg-gray-800 hover:bg-gray-700 text-white py-2 rounded-lg font-medium transition duration-300">
-              Add to Collection
+              View Product
             </button>
+            </a>
           </div>
         @endforeach
       </div>

--- a/resources/views/template2/single-product2.blade.php
+++ b/resources/views/template2/single-product2.blade.php
@@ -1,0 +1,38 @@
+@include('template2.head2', ['is_default' => $is_default, 'headerFooter' => $headerFooter])
+
+<section class="py-20 px-6 bg-white">
+  <div class="max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+      <div>
+        <div class="relative h-[500px] mb-6 overflow-hidden rounded-lg">
+          <img src="{{ $product->image_url }}" alt="{{ $product->name }}" class="absolute inset-0 w-full h-full object-cover">
+        </div>
+      </div>
+      <div>
+        <h2 class="text-4xl font-medium mb-4">{{ $product->name }}</h2>
+        <p class="text-gray-600 mb-6">{{ $product->description }}</p>
+        <p class="text-gray-900 font-medium text-3xl mb-6">${{ number_format($product->price, 2) }}</p>
+        <div class="flex items-center mb-6">
+          <div class="flex text-yellow-500">
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star-half-alt"></i>
+          </div>
+          <p class="text-gray-600 ml-2">4.5 (1,234 reviews)</p>
+        </div>
+        <div class="flex space-x-4">
+          <button class="bg-indigo-600 hover:bg-indigo-700 text-white px-8 py-3 font-medium transition duration-300">
+            Add to Cart
+          </button>
+          <button class="border border-gray-300 hover:border-indigo-600 text-gray-900 px-8 py-3 font-medium transition duration-300">
+            Add to Wishlist
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+@include('template2.footer2')

--- a/resources/views/template3/head3.blade.php
+++ b/resources/views/template3/head3.blade.php
@@ -82,12 +82,14 @@
           
           @if($headerFooterId)
             <a href="/index3/{{ $headerFooterId }}" class="text-gray-700 nav-link">Home</a>
+            <a href="/product3/{{ $headerFooterId }}" class="text-gray-700 nav-link">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }}  nav-link">Features</a>
             <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }}  nav-link">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }}  nav-link">Collection</a>
             <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }}  nav-link">Contact</a>
           @else
             <a href="/index3" class="text-gray-700 nav-link">Home</a>
+            <a href="/product3" class="text-gray-700 nav-link">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }}  nav-link">Features</a>
             <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }}  nav-link">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }}  nav-link">Collection</a>

--- a/resources/views/template3/index3.blade.php
+++ b/resources/views/template3/index3.blade.php
@@ -46,10 +46,10 @@
           
           <div class="flex space-x-4">
             @if($headerFooterId)
-              <button class="bg-pink-600 hover:bg-pink-700 text-white px-8 py-3 font-medium transition duration-300" onclick="window.location.href='/product3/{{ $headerFooterId }}'">
+              <button class="bg-pink-600 hover:bg-pink-700 text-white px-8 py-3 font-medium transition duration-300" onclick="window.location.href='/product3/{{ $headerFooter->id }}'">
                 {{ $homesetting->button1_text }}
               </button>
-              <button class="border border-gray-300 hover:border-pink-600 text-gray-900 px-8 py-3 font-medium transition duration-300" onclick="window.location.href='/product3/{{ $headerFooterId }}'">
+              <button class="border border-gray-300 hover:border-pink-600 text-gray-900 px-8 py-3 font-medium transition duration-300" onclick="window.location.href='/product3/{{ $headerFooter->id }}'">
                 {{ $homesetting->button2_text }}
               </button>
             @else
@@ -220,8 +220,8 @@
     <section id="collection" class="py-20 px-6 bg-white">
       <div class="max-w-7xl mx-auto">
         <div class="text-center mb-16">
-          <h3 class="text-3xl font-medium mb-4">{{ $section3->main_text ?? 'Best Collections' }}</h3>
-          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section3->sub_text ?? 'Perfect choices specially for you' }}</p>
+          <h3 class="text-3xl font-medium mb-4">{{ $section2->main_text2 ?? 'Best Collections' }}</h3>
+          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section2->sub_text2 ?? 'Perfect choices specially for you' }}</p>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           @foreach($products as $product)

--- a/resources/views/template3/product3.blade.php
+++ b/resources/views/template3/product3.blade.php
@@ -11,7 +11,7 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           <!-- Static Product Cards -->
-          @include('template2.collection-default')
+          @include('template3.collection-default')
         </div>
         <div class="text-center mt-12">
           <button class="border border-gray-900 hover:bg-gray-900 hover:text-white text-gray-900 px-8 py-3 rounded-lg font-medium transition duration-300">
@@ -24,8 +24,8 @@
     <section id="collection" class="py-20 px-6 bg-white">
       <div class="max-w-7xl mx-auto">
         <div class="text-center mb-16">
-          <h3 class="text-3xl font-medium mb-4">{{ $section3->main_text ?? 'Best Collections' }}</h3>
-          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section3->sub_text ?? 'Perfect choices specially for you' }}</p>
+          <h3 class="text-3xl font-medium mb-4">{{ $section2->main_text2 ?? 'Best Collections' }}</h3>
+          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section2->sub_text2 ?? 'Perfect choices specially for you' }}</p>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           @foreach($products as $product)
@@ -39,12 +39,14 @@
                   <span class="absolute top-4 right-4 bg-white text-gray-900 text-xs font-medium px-2 py-1 rounded">LIMITED</span>
                 @endif
               </div>
+              <a href="{{ route('template3.single-product', ['headerFooterId' => $headerFooter->id, 'productId' => $product->id]) }}">
               <h4 class="font-medium text-lg mb-1">{{ $product->name }}</h4>
               <p class="text-gray-500 text-sm mb-3">{{ $product->description }}</p>
               <p class="text-gray-900 font-medium text-xl mb-4">${{ number_format($product->price, 2) }}</p>
               <button class="w-full border border-gray-900 hover:bg-gray-900 hover:text-white text-gray-900 py-2 rounded-lg font-medium transition duration-300">
-                Add to Cart
+                View Product
               </button>
+              </a>
             </div>
           @endforeach
         </div>

--- a/resources/views/template3/single-product3.blade.php
+++ b/resources/views/template3/single-product3.blade.php
@@ -1,0 +1,38 @@
+@include('template3.head3', ['is_default' => $is_default, 'headerFooter' => $headerFooter])
+
+<section class="py-20 px-6 bg-white">
+  <div class="max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+      <div>
+        <div class="relative h-[500px] mb-6 overflow-hidden rounded-lg">
+          <img src="{{ $product->image_url }}" alt="{{ $product->name }}" class="absolute inset-0 w-full h-full object-cover">
+        </div>
+      </div>
+      <div>
+        <h2 class="text-4xl font-medium mb-4">{{ $product->name }}</h2>
+        <p class="text-gray-600 mb-6">{{ $product->description }}</p>
+        <p class="text-gray-900 font-medium text-3xl mb-6">${{ number_format($product->price, 2) }}</p>
+        <div class="flex items-center mb-6">
+          <div class="flex text-yellow-500">
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star-half-alt"></i>
+          </div>
+          <p class="text-gray-600 ml-2">4.5 (1,234 reviews)</p>
+        </div>
+        <div class="flex space-x-4">
+          <button class="bg-pink-600 hover:bg-pink-700 text-white px-8 py-3 font-medium transition duration-300">
+            Add to Cart
+          </button>
+          <button class="border border-gray-300 hover:border-pink-600 text-gray-900 px-8 py-3 font-medium transition duration-300">
+            Add to Wishlist
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+@include('template3.footer3')

--- a/resources/views/template4/head4.blade.php
+++ b/resources/views/template4/head4.blade.php
@@ -105,14 +105,16 @@
           
           @if($headerFooterId)
             <a href="/index4/{{ $headerFooterId }}" class="text-gray-700 nav-link">Home</a>
+            <a href="/product4/{{ $headerFooterId }}" class="text-gray-700 nav-link">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }}  nav-link">Features</a>
             <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }}  nav-link">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }}  nav-link">Collection</a>
             <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }}  nav-link">Contact</a>
           @else
             <a href="/index4" class="text-gray-700 nav-link">Home</a>
+            <a href="/product4" class="text-gray-700 nav-link">Products</a>
             <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }}  nav-link">Features</a>
-            <a href="#brands" id="navBrands" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }}  nav-link">Categories</a>
+            <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }}  nav-link">Categories</a>
             <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }}  nav-link">Collection</a>
             <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }}  nav-link">Contact</a>
           @endif

--- a/resources/views/template4/index4.blade.php
+++ b/resources/views/template4/index4.blade.php
@@ -305,9 +305,9 @@
       <div class="max-w-7xl mx-auto">
         <div class="text-center mb-16">
           <h3 class="text-3xl font-semibold mb-4">
-            <span class="text-[#d4af37]">{{ $section3->main_text ?? 'Best Collections' }}</span>
+            <span class="text-[#d4af37]">{{ $section2->main_text2 ?? 'Best Collections' }}</span>
           </h3>
-          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section3->sub_text ?? 'Perfect choices specially for you' }}</p>
+          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section2->sub_text2 ?? 'Perfect choices specially for you' }}</p>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           @foreach($products as $product)

--- a/resources/views/template4/product4.blade.php
+++ b/resources/views/template4/product4.blade.php
@@ -81,9 +81,9 @@
       <div class="max-w-7xl mx-auto">
         <div class="text-center mb-16">
           <h3 class="text-3xl font-semibold mb-4">
-            <span class="text-[#d4af37]">{{ $section3->main_text ?? 'Best Collections' }}</span>
+            <span class="text-[#d4af37]">{{ $section2->main_text2 ?? 'Best Collections' }}</span>
           </h3>
-          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section3->sub_text ?? 'Perfect choices specially for you' }}</p>
+          <p class="text-gray-600 max-w-2xl mx-auto">{{ $section2->sub_text2 ?? 'Perfect choices specially for you' }}</p>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           @foreach($products as $product)
@@ -97,12 +97,14 @@
                   <span class="absolute top-4 right-4 bg-[#d4af37] text-white text-xs font-medium px-2 py-1 rounded">LIMITED</span>
                 @endif
               </div>
+              <a href="{{ route('template4.single-product', ['headerFooterId' => $headerFooter->id, 'productId' => $product->id]) }}">
               <h4 class="font-semibold text-lg mb-1">{{ $product->name }}</h4>
               <p class="text-gray-500 text-sm mb-3">{{ $product->description }}</p>
               <p class="text-gray-900 font-semibold text-xl mb-4">${{ number_format($product->price, 2) }}</p>
               <button class="w-full btn-gold py-2 rounded font-medium">
-                Add to Collection
+                View Product
               </button>
+              </a>
             </div>
           @endforeach
         </div>

--- a/resources/views/template4/single-product4.blade.php
+++ b/resources/views/template4/single-product4.blade.php
@@ -1,0 +1,38 @@
+@include('template4.head4', ['is_default' => $is_default, 'headerFooter' => $headerFooter])
+
+<section class="py-20 px-6 bg-white">
+  <div class="max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+      <div>
+        <div class="relative h-[500px] mb-6 overflow-hidden rounded-lg">
+          <img src="{{ $product->image_url }}" alt="{{ $product->name }}" class="absolute inset-0 w-full h-full object-cover">
+        </div>
+      </div>
+      <div>
+        <h2 class="text-4xl font-medium mb-4">{{ $product->name }}</h2>
+        <p class="text-gray-600 mb-6">{{ $product->description }}</p>
+        <p class="text-gray-900 font-medium text-3xl mb-6">${{ number_format($product->price, 2) }}</p>
+        <div class="flex items-center mb-6">
+          <div class="flex text-yellow-500">
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star"></i>
+            <i class="fas fa-star-half-alt"></i>
+          </div>
+          <p class="text-gray-600 ml-2">4.5 (1,234 reviews)</p>
+        </div>
+        <div class="flex space-x-4">
+          <button class="bg-teal-600 hover:bg-teal-700 text-white px-8 py-3 font-medium transition duration-300">
+            Add to Cart
+          </button>
+          <button class="border border-gray-300 hover:border-teal-600 text-gray-900 px-8 py-3 font-medium transition duration-300">
+            Add to Wishlist
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+@include('template4.footer4')

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,11 @@ Route::get('/product1/{headerFooterId}', [ProductController1::class, 'showCustom
 Route::get('/product2/{headerFooterId}', [ProductController2::class, 'showCustomer'])->name('template2.product2.customer');
 Route::get('/product3/{headerFooterId}', [ProductController3::class, 'showCustomer'])->name('template3.product3.customer');
 Route::get('/product4/{headerFooterId}', [ProductController4::class, 'showCustomer'])->name('template4.product4.customer');
+Route::get('/single-product1/{headerFooterId}/{productId}', [ProductController1::class, 'showSingleProduct'])->name('template1.single-product');
+Route::get('/single-product2/{headerFooterId}/{productId}', [ProductController2::class, 'showSingleProduct'])->name('template2.single-product');
+Route::get('/single-product3/{headerFooterId}/{productId}', [ProductController3::class, 'showSingleProduct'])->name('template3.single-product');
+Route::get('/single-product4/{headerFooterId}/{productId}', [ProductController4::class, 'showSingleProduct'])->name('template4.single-product');
+
 
 // Site customer auth endpoints (AJAX)
 Route::get('/customer/check-auth', [SiteCustomerAuthController::class, 'checkAuth']);


### PR DESCRIPTION
- Adds product listing and single product detail pages for all 4 templates.
- Includes routes, controller methods, and views for the new pages.
- Adds a 'Products' link to the header navigation of each template.
- Fixes a bug on the index pages where a section heading was not displaying correctly due to an incorrect variable reference.