### PR TITLE
Fix product images not loading due to missing storage symlink

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ImageController extends Controller
+{
+    public function show($path)
+    {
+        if (!Storage::disk('public')->exists($path)) {
+            throw new NotFoundHttpException();
+        }
+
+        return Storage::disk('public')->response($path);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,10 +15,14 @@ use App\Http\Controllers\ProductController4;
 use App\Http\Controllers\TemplateSelectionController;
 use App\Http\Controllers\TemplateViewController;
 use App\Http\Controllers\Customer\SiteCustomerAuthController;
+use App\Http\Controllers\ImageController;
 
 // Public routes
 Route::get('/', fn() => view('index'));
 Route::get('/register', fn() => view('register'));
+
+// Route to handle storage files
+Route::get('/storage/{path}', [ImageController::class, 'show'])->where('path', '.*');
 
 // Auth routes
 Route::post('/register', [AuthController::class, 'register']);


### PR DESCRIPTION
The product images were returning 404 errors because the application was generating URLs pointing to `public/storage`, but the symbolic link from `public/storage` to `storage/app/public` was not present.

Since the environment does not allow for creating the symlink via `php artisan storage:link`, this change implements an application-level workaround.

A new `ImageController` has been created to serve files directly from the `storage/app/public` directory. A corresponding route has been added to `routes/web.php` to intercept requests for files under `/storage/` and pass them to this controller.

No frontend changes are necessary because the existing model accessors already generate the correct `/storage/...` URLs. This solution intercepts these URLs at the routing level to serve the files from their actual location.