### PR TITLE
fix: Correctly pass header_footer_id in navigation links

### DIFF
--- a/resources/views/template1/head1.blade.php
+++ b/resources/views/template1/head1.blade.php
@@ -62,31 +62,12 @@
         <a href="/index1" class="text-gray-700 hover:text-pink-600 transition">Home</a>
         <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
       @else
-        @php
-          $currentUrl = request()->url();
-          $headerFooterId = null;
-          if (preg_match('/\/index1\/(\d+)/', $currentUrl, $matches)) {
-            $headerFooterId = $matches[1];
-          } elseif (preg_match('/\/product1\/(\d+)/', $currentUrl, $matches)) {
-            $headerFooterId = $matches[1];
-          }
-        @endphp
-        
-        @if($headerFooterId)
-          <a href="/index1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-          <a href="/product1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
-          <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
-          <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
-        @else
-          <a href="/index1" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-          <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
-          <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
-          <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
-        @endif
+        <a href="{{ route('template1.index1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+        <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
+        <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
+        <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
+        <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
+        <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
       @endif
     </nav>
     <div class="md:hidden">
@@ -125,21 +106,12 @@
         <a href="/index1" class="text-gray-700 hover:text-pink-600 transition">Home</a>
         <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
       @else
-        @if($headerFooterId)
-          <a href="/index1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-          <a href="/product1/{{ $headerFooterId }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
-          <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
-          <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
-        @else
-          <a href="/index1" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-          <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
-          <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
-          <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
-        @endif
+        <a href="{{ route('template1.index1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
+        <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
+        <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
+        <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
+        <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
+        <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-600">Contact</a>
       @endif
       <button id="authButtonMobile" onclick="openLoginModal()" class="bg-pink-600 hover:bg-pink-700 text-white px-4 py-2 rounded transition">
         <span id="authButtonTextMobile">Sign In</span>

--- a/resources/views/template2/head2.blade.php
+++ b/resources/views/template2/head2.blade.php
@@ -84,31 +84,12 @@
           <a href="/index2" class="text-gray-300 hover:text-pink-500 transition">Home</a>
           <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
         @else
-          @php
-            $currentUrl = request()->url();
-            $headerFooterId = null;
-            if (preg_match('/\/index2\/(\d+)/', $currentUrl, $matches)) {
-              $headerFooterId = $matches[1];
-            } elseif (preg_match('/\/product2\/(\d+)/', $currentUrl, $matches)) {
-              $headerFooterId = $matches[1];
-            }
-          @endphp
-
-          @if($headerFooterId)
-            <a href="/index2/{{ $headerFooterId }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-            <a href="/product2/{{ $headerFooterId }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
-            <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
-            <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
-            <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
-            <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
-          @else
-            <a href="/index2" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-            <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
-            <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
-            <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
-            <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
-            <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
-          @endif
+          <a href="{{ route('template2.index2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
+          <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
+          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
+          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
+          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
+          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
         @endif
       </nav>
       <div class="md:hidden">
@@ -147,21 +128,12 @@
         <a href="/index2" class="text-gray-300 hover:text-pink-500 transition">Home</a>
         <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
       @else
-        @if($headerFooterId)
-          <a href="/index2/{{ $headerFooterId }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-          <a href="/product2/{{ $headerFooterId }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
-        @else
-          <a href="/index2" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-          <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
-        @endif
+        <a href="{{ route('template2.index2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
+        <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
+        <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
+        <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
+        <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
+        <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} hover:text-pink-500">Contact</a>
       @endif
     </nav>
   </div>

--- a/resources/views/template3/head3.blade.php
+++ b/resources/views/template3/head3.blade.php
@@ -56,31 +56,12 @@
               <a href="/index3" class="text-gray-500 hover:text-blue-600">Home</a>
               <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
             @else
-              @php
-                $currentUrl = request()->url();
-                $headerFooterId = null;
-                if (preg_match('/\/index3\/(\d+)/', $currentUrl, $matches)) {
-                  $headerFooterId = $matches[1];
-                } elseif (preg_match('/\/product3\/(\d+)/', $currentUrl, $matches)) {
-                  $headerFooterId = $matches[1];
-                }
-              @endphp
-
-              @if($headerFooterId)
-                <a href="/index3/{{ $headerFooterId }}" class="text-gray-500 hover:text-blue-600">Home</a>
-                <a href="/product3/{{ $headerFooterId }}" class="text-gray-500 hover:text-blue-600">Products</a>
-                <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
-                <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
-                <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
-                <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
-              @else
-                <a href="/index3" class="text-gray-500 hover:text-blue-600">Home</a>
-                <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
-                <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
-                <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
-                <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
-                <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
-              @endif
+              <a href="{{ route('template3.index3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Home</a>
+              <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
+              <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
+              <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
+              <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
+              <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
             @endif
         </nav>
         <div class="md:hidden">
@@ -116,21 +97,12 @@
         <a href="/index3" class="text-gray-500 hover:text-blue-600">Home</a>
         <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
       @else
-        @if($headerFooterId)
-          <a href="/index3/{{ $headerFooterId }}" class="text-gray-500 hover:text-blue-600">Home</a>
-          <a href="/product3/{{ $headerFooterId }}" class="text-gray-500 hover:text-blue-600">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
-        @else
-          <a href="/index3" class="text-gray-500 hover:text-blue-600">Home</a>
-          <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
-        @endif
+        <a href="{{ route('template3.index3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Home</a>
+        <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
+        <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
+        <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
+        <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
+        <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Contact</a>
       @endif
     </nav>
   </div>

--- a/resources/views/template4/head4.blade.php
+++ b/resources/views/template4/head4.blade.php
@@ -68,31 +68,12 @@
                 <a href="/index4" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
                 <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
             @else
-                @php
-                $currentUrl = request()->url();
-                $headerFooterId = null;
-                if (preg_match('/\/index4\/(\d+)/', $currentUrl, $matches)) {
-                    $headerFooterId = $matches[1];
-                } elseif (preg_match('/\/product4\/(\d+)/', $currentUrl, $matches)) {
-                    $headerFooterId = $matches[1];
-                }
-                @endphp
-
-                @if($headerFooterId)
-                <a href="/index4/{{ $headerFooterId }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-                <a href="/product4/{{ $headerFooterId }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
+                <a href="{{ route('template4.index4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
+                <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
                 <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
                 <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
                 <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
                 <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
-                @else
-                <a href="/index4" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-                <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
-                <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
-                <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
-                <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
-                <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
-                @endif
             @endif
         </nav>
         <div class="md:hidden">
@@ -132,21 +113,12 @@
         <a href="/index4" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
         <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
       @else
-        @if($headerFooterId)
-          <a href="/index4/{{ $headerFooterId }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-          <a href="/product4/{{ $headerFooterId }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
-        @else
-          <a href="/index4" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-          <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
-          <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
-          <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
-          <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
-          <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
-        @endif
+        <a href="{{ route('template4.index4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
+        <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
+        <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
+        <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
+        <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
+        <a href="#contact" id="navContact" class="{{ !($headerFooter->contact ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
       @endif
       <button id="authButtonMobile" onclick="openLoginModal()" class="w-full whitespace-nowrap inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-purple-600 hover:bg-purple-700">
         <span id="authButtonTextMobile">Sign In</span>


### PR DESCRIPTION
The navigation links in the template headers were not correctly passing the `header_footer_id` when navigating from pages like the cart or wishlist. This was because the ID was being parsed from the URL, and this logic failed on pages with different URL structures.

This commit refactors the navigation links in all four template headers (`head1.blade.php`, `head2.blade.php`, `head3.blade.php`, and `head4.blade.php`) to use the `route()` helper with the `$headerFooter->id`. This ensures that the ID is always correctly included in the links, regardless of the current page.