### PR TITLE
refactor: Unify product page URL and controller

### DIFF
--- a/app/Http/Controllers/UnifiedProductController.php
+++ b/app/Http/Controllers/UnifiedProductController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\HeaderFooter;
+use App\Models\SelectedTemplate;
+use App\Models\Product;
+use App\Models\Cart;
+use App\Models\Wishlist;
+use Illuminate\Support\Facades\Session;
+
+class UnifiedProductController extends Controller
+{
+    /**
+     * Display the specified resource.
+     */
+    public function show(Request $request, string $headerFooterId)
+    {
+        $headerFooter = HeaderFooter::find($headerFooterId);
+
+        if (!$headerFooter) {
+            abort(404, 'Header/Footer not found');
+        }
+
+        // Determine the template to use
+        $selectedTemplate = SelectedTemplate::where('header_footer_id', $headerFooterId)->first();
+        if (!$selectedTemplate) {
+            abort(404, 'Template not found for this website.');
+        }
+
+        // Extract template number from template_name (e.g., 'template1.index1' -> '1')
+        preg_match('/template(\d+)/', $selectedTemplate->template_name, $matches);
+        $templateId = $matches[1] ?? '1'; // Default to 1 if not found
+
+        // Fetch products
+        $query = Product::where('header_footer_id', $headerFooterId);
+
+        // Sorting
+        if ($request->has('sort')) {
+            if ($request->get('sort') == 'price_asc') {
+                $query->orderBy('price', 'asc');
+            } elseif ($request->get('sort') == 'price_desc') {
+                $query->orderBy('price', 'desc');
+            }
+        }
+
+        // Filtering by price range
+        if ($request->has('min_price')) {
+            $query->where('price', '>=', $request->get('min_price'));
+        }
+        if ($request->has('max_price')) {
+            $query->where('price', '<=', $request->get('max_price'));
+        }
+
+        // Filtering by category name
+        if ($request->has('category_name')) {
+            $query->where('category_name', $request->get('category_name'));
+        }
+
+        $products = $query->get();
+
+        // Construct the view name dynamically
+        $viewName = 'template' . $templateId . '.product' . $templateId;
+
+        // We also need cart and wishlist counts for the header
+        $siteCustomerId = Session::get('site_customer_id');
+        $sessionId = Session::getId();
+        $cartCount = Cart::where('header_footer_id', $headerFooterId)->where(function ($query) use ($siteCustomerId, $sessionId) {
+            if ($siteCustomerId) $query->where('site_customer_id', $siteCustomerId);
+            else $query->where('session_id', $sessionId);
+        })->sum('quantity');
+
+        $wishlistCount = Wishlist::where('header_footer_id', $headerFooterId)->where(function ($query) use ($siteCustomerId, $sessionId) {
+            if ($siteCustomerId) $query->where('site_customer_id', $siteCustomerId);
+            else $query->where('session_id', $sessionId);
+        })->count();
+
+        return view($viewName, [
+            'headerFooter' => $headerFooter,
+            'products' => $products,
+            'is_default' => false,
+            'cartCount' => $cartCount,
+            'wishlistCount' => $wishlistCount,
+            'headerFooterId' => $headerFooterId // Pass this for convenience in the view
+        ]);
+    }
+}

--- a/resources/views/template1/cart1.blade.php
+++ b/resources/views/template1/cart1.blade.php
@@ -47,7 +47,7 @@
                         <i class="fas fa-shopping-cart text-6xl text-gray-300"></i>
                         <h3 class="mt-4 text-2xl font-bold text-gray-800">Your cart is empty.</h3>
                         <p class="text-gray-500 mt-2">Looks like you haven't added anything to your cart yet.</p>
-                        <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
                             Continue Shopping
                         </a>
                     </div>
@@ -73,7 +73,7 @@
                     <button id="checkout-btn" class="w-full mt-6 bg-pink-600 hover:bg-pink-700 text-white py-3 px-4 rounded-lg font-bold text-lg transition">
                         Proceed to Checkout
                     </button>
-                    <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
+                    <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
                         or Continue Shopping
                     </a>
                 </div>

--- a/resources/views/template1/head1.blade.php
+++ b/resources/views/template1/head1.blade.php
@@ -63,7 +63,7 @@
         <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
       @else
         <a href="{{ route('template1.index1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-        <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
+        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
         <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
         <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
         <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>
@@ -107,7 +107,7 @@
         <a href="/product1" class="text-gray-700 hover:text-pink-600 transition">Products</a>
       @else
         <a href="{{ route('template1.index1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Home</a>
-        <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
+        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-700 hover:text-pink-600 transition">Products</a>
         <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-600">Features</a>
         <a href="#categories" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-600">Categories</a>
         <a href="#products" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-600">Collection</a>

--- a/resources/views/template1/wishlist1.blade.php
+++ b/resources/views/template1/wishlist1.blade.php
@@ -39,7 +39,7 @@
                 <i class="fas fa-heart text-6xl text-gray-300"></i>
                 <h3 class="mt-4 text-2xl font-bold text-gray-800">Your wishlist is empty.</h3>
                 <p class="text-gray-500 mt-2">Looks like you haven't added anything to your wishlist yet.</p>
-                <a href="{{ route('template1.product1.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
                     Continue Shopping
                 </a>
             </div>

--- a/resources/views/template2/cart2.blade.php
+++ b/resources/views/template2/cart2.blade.php
@@ -47,7 +47,7 @@
                         <i class="fas fa-shopping-cart text-6xl text-gray-700"></i>
                         <h3 class="mt-4 text-2xl font-light text-white">Your cart is empty.</h3>
                         <p class="text-gray-400 mt-2">Looks like you haven't added anything to your cart yet.</p>
-                        <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block bg-pink-600 text-white px-8 py-3 rounded-md hover:bg-pink-700 transition-colors">
                             Continue Shopping
                         </a>
                     </div>
@@ -73,7 +73,7 @@
                     <button id="checkout-btn" class="w-full mt-6 bg-pink-600 hover:bg-pink-700 text-white py-3 px-4 rounded-lg font-bold text-lg transition">
                         Proceed to Checkout
                     </button>
-                    <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-500 hover:text-pink-400 font-medium">
+                    <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-500 hover:text-pink-400 font-medium">
                         or Continue Shopping
                     </a>
                 </div>

--- a/resources/views/template2/head2.blade.php
+++ b/resources/views/template2/head2.blade.php
@@ -85,7 +85,7 @@
           <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
         @else
           <a href="{{ route('template2.index2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-          <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
+          <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
           <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
           <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
           <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>
@@ -129,7 +129,7 @@
         <a href="/product2" class="text-gray-300 hover:text-pink-500 transition">Products</a>
       @else
         <a href="{{ route('template2.index2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Home</a>
-        <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
+        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-300 hover:text-pink-500 transition">Products</a>
         <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} hover:text-pink-500">Features</a>
         <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} hover:text-pink-500">Categories</a>
         <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} hover:text-pink-500">Collection</a>

--- a/resources/views/template2/wishlist2.blade.php
+++ b/resources/views/template2/wishlist2.blade.php
@@ -39,7 +39,7 @@
                 <i class="fas fa-heart text-6xl text-gray-700"></i>
                 <h3 class="mt-4 text-2xl font-light text-white">Your wishlist is empty.</h3>
                 <p class="text-gray-400 mt-2">Looks like you haven't added anything to your wishlist yet.</p>
-                <a href="{{ route('template2.product2.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
                     Continue Shopping
                 </a>
             </div>

--- a/resources/views/template3/cart3.blade.php
+++ b/resources/views/template3/cart3.blade.php
@@ -47,7 +47,7 @@
                         <i class="fas fa-shopping-cart text-6xl text-gray-300"></i>
                         <h3 class="mt-4 text-2xl font-bold text-gray-800">Your cart is empty.</h3>
                         <p class="text-gray-500 mt-2">Looks like you haven't added anything to your cart yet.</p>
-                        <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block bg-blue-600 text-white px-8 py-3 rounded-md hover:bg-blue-700 transition-colors">
                             Continue Shopping
                         </a>
                     </div>
@@ -73,7 +73,7 @@
                     <button id="checkout-btn" class="w-full mt-6 bg-pink-600 hover:bg-pink-700 text-white py-3 px-4 rounded-lg font-bold text-lg transition">
                         Proceed to Checkout
                     </button>
-                    <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
+                    <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
                         or Continue Shopping
                     </a>
                 </div>

--- a/resources/views/template3/head3.blade.php
+++ b/resources/views/template3/head3.blade.php
@@ -57,7 +57,7 @@
               <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
             @else
               <a href="{{ route('template3.index3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Home</a>
-              <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
+              <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
               <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
               <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
               <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>
@@ -98,7 +98,7 @@
         <a href="/product3" class="text-gray-500 hover:text-blue-600">Products</a>
       @else
         <a href="{{ route('template3.index3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Home</a>
-        <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
+        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-gray-500 hover:text-blue-600">Products</a>
         <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Features</a>
         <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Categories</a>
         <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-gray-500 hover:text-blue-600">Collection</a>

--- a/resources/views/template3/wishlist3.blade.php
+++ b/resources/views/template3/wishlist3.blade.php
@@ -39,7 +39,7 @@
                 <i class="fas fa-heart text-6xl text-gray-300"></i>
                 <h3 class="mt-4 text-2xl font-bold text-gray-800">Your wishlist is empty.</h3>
                 <p class="text-gray-500 mt-2">Looks like you haven't added anything to your wishlist yet.</p>
-                <a href="{{ route('template3.product3.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block bg-blue-600 text-white px-8 py-3 rounded-md hover:bg-blue-700 transition-colors">
                     Continue Shopping
                 </a>
             </div>

--- a/resources/views/template4/cart4.blade.php
+++ b/resources/views/template4/cart4.blade.php
@@ -47,7 +47,7 @@
                         <i class="fas fa-shopping-cart text-6xl text-gray-300"></i>
                         <h3 class="mt-4 text-2xl font-bold text-gray-800">Your cart is empty.</h3>
                         <p class="text-gray-500 mt-2">Looks like you haven't added anything to your cart yet.</p>
-                        <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block bg-purple-600 text-white px-8 py-3 rounded-md hover:bg-purple-700 transition-colors">
                             Continue Shopping
                         </a>
                     </div>
@@ -73,7 +73,7 @@
                     <button id="checkout-btn" class="w-full mt-6 bg-pink-600 hover:bg-pink-700 text-white py-3 px-4 rounded-lg font-bold text-lg transition">
                         Proceed to Checkout
                     </button>
-                    <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
+                    <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="block text-center mt-4 text-pink-600 hover:text-pink-500 font-medium">
                         or Continue Shopping
                     </a>
                 </div>

--- a/resources/views/template4/head4.blade.php
+++ b/resources/views/template4/head4.blade.php
@@ -69,7 +69,7 @@
                 <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
             @else
                 <a href="{{ route('template4.index4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-                <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
+                <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
                 <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
                 <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
                 <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>
@@ -114,7 +114,7 @@
         <a href="/product4" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
       @else
         <a href="{{ route('template4.index4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-        <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
+        <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="text-base font-medium text-gray-500 hover:text-gray-900">Products</a>
         <a href="#features" id="navFeatures" class="{{ !($headerFooter->features ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Features</a>
         <a href="#brands" id="navBrands" class="{{ !($headerFooter->brands ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Categories</a>
         <a href="#collection" id="navCollections" class="{{ !($headerFooter->collections ?? false) ? 'hidden' : '' }} text-base font-medium text-gray-500 hover:text-gray-900">Collection</a>

--- a/resources/views/template4/wishlist4.blade.php
+++ b/resources/views/template4/wishlist4.blade.php
@@ -39,7 +39,7 @@
                 <i class="fas fa-heart text-6xl text-gray-300"></i>
                 <h3 class="mt-4 text-2xl font-bold text-gray-800">Your wishlist is empty.</h3>
                 <p class="text-gray-500 mt-2">Looks like you haven't added anything to your wishlist yet.</p>
-                <a href="{{ route('template4.product4.customer', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block px-6 py-3 bg-pink-600 text-white rounded-lg hover:bg-pink-700 font-medium">
+                <a href="{{ route('products.show', ['headerFooterId' => $headerFooter->id]) }}" class="mt-6 inline-block bg-purple-600 text-white px-8 py-3 rounded-md hover:bg-purple-700 transition-colors">
                     Continue Shopping
                 </a>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\CartController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\WishlistController;
 use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\UnifiedProductController;
 
 // Public routes
 Route::get('/', fn() => view('index'));
@@ -92,6 +93,7 @@ Route::get('/single-product3', [ProductController3::class, 'index'])->name('temp
 Route::get('/single-product4', [ProductController4::class, 'index'])->name('template4.single-product4');
 
 // Customer-facing product routes with header_footer_id
+Route::get('/products/{headerFooterId}', [UnifiedProductController::class, 'show'])->name('products.show');
 Route::get('/product1/{headerFooterId}', [ProductController1::class, 'showCustomer'])->name('template1.product1.customer');
 Route::get('/product2/{headerFooterId}', [ProductController2::class, 'showCustomer'])->name('template2.product2.customer');
 Route::get('/product3/{headerFooterId}', [ProductController3::class, 'showCustomer'])->name('template3.product3.customer');


### PR DESCRIPTION
This commit refactors the way product pages are handled in the application. Previously, each template had its own route and controller for its product page (e.g., `/product1/{id}`, `ProductController1.php`). This led to inconsistent URLs and code duplication.

This commit introduces a new, unified route `/products/{headerFooterId}` and a corresponding `UnifiedProductController`. This new controller dynamically determines which template to render based on the website's settings, providing a single, consistent URL for all product pages.

The changes include:
- Creation of `UnifiedProductController` to handle all product page logic.
- Addition of a new `GET /products/{headerFooterId}` route.
- Updates to all template headers to use the new unified route for the "Products" link.
- Updates to all "Continue Shopping" links in cart and wishlist views to use the new route.